### PR TITLE
修复字幕文件命名不规范时优先级判断问题

### DIFF
--- a/getsub/main.py
+++ b/getsub/main.py
@@ -314,10 +314,10 @@ class GetSubtitles(object):
                     score[-1] += 5
                 if '繁体' in one_sub or 'cht' in one_sub or '.big5.' in one_sub:
                     score[-1] += 3
-                if '中英' in one_sub or '简英' in one_sub or '双语' in one_sub \
-                        or 'chs.eng' in one_sub or 'chs&eng' in one_sub \
-                        or '简体&英文' in one_sub:
+                if 'chs.eng' in one_sub or 'chs&eng' in one_sub:
                     score[-1] += 7
+                if '中英' in one_sub or '简英' in one_sub or '双语' in one_sub or '简体&英文' in one_sub:
+                    score[-1] +=9
             # py2 strange decode error, happens time to time
             except UnicodeDecodeError:
                 if '简体'.decode('utf8') in one_sub \
@@ -326,13 +326,14 @@ class GetSubtitles(object):
                 if '繁体'.decode('utf8') in one_sub \
                         or 'cht' in one_sub or '.big5.' in one_sub:
                     score[-1] += 3
+                if 'chs.eng'.decode('utf8') in one_sub \
+                        or 'chs&eng' in one_sub:
+                    score[-1] += 7
                 if '中英'.decode('utf8') in one_sub \
                         or '简英'.decode('utf8') in one_sub \
                         or '双语'.decode('utf8') in one_sub \
-                        or '简体&英文'.decode('utf8') in one_sub \
-                        or 'chs.eng'.decode('utf8') in one_sub \
-                        or 'chs&eng' in one_sub:
-                    score[-1] += 7
+                        or '简体&英文'.decode('utf8') in one_sub:
+                    score[-1] += 9				
 
             score[-1] += ('ass' in one_sub or 'ssa' in one_sub) * 2
             score[-1] += ('srt' in one_sub) * 1


### PR DESCRIPTION
经常会遇到下图字幕文件，导致无法正确判断，将 chs.eng 与 简体&英文 等中文关键字分离判断，含有中文优先级更高

![Snipaste_2019-12-08_16-12-09.png](https://i.loli.net/2019/12/08/I2ABDwFk5pluiVU.png)
