### PR TITLE
修复 subhd dtoken 变更 dtoken1，导致无法下载

### DIFF
--- a/getsub/downloader/subhd.py
+++ b/getsub/downloader/subhd.py
@@ -104,11 +104,11 @@ class SubHDDownloader(Downloader):
         sid = sub_url.split("/")[-1]
         r = session.get(sub_url)
         bs_obj = BeautifulSoup(r.text, "html.parser")
-        dtoken = bs_obj.find("button", {"id": "down"})["dtoken"]
+        dtoken = bs_obj.find("button", {"id": "down"})["dtoken1"]
 
         r = session.post(
             SubHDDownloader.site_url + "/ajax/down_ajax",
-            data={"sub_id": sid, "dtoken": dtoken},
+            data={"sub_id": sid, "dtoken1": dtoken},
         )
 
         content = r.content.decode("unicode-escape")


### PR DESCRIPTION
刚下载字幕的时候，发现一直报错 error：dtoken。

通过查看源码和 subhd 源码，发现 dtoken 改为 dtoken1。
